### PR TITLE
stack tracking

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,14 @@
-// have accesserror return more info (addr of invalid access)
-// memory w/ 3 states: unallocated, valid to write to, fully initialized
-// set stack pointer or alloc stack / free stack; designates memory as stack
-
 struct Valgrind {
-    metadata: Vec<MemState>
+    metadata: Vec<MemState>,
+    stack_pointer: usize,
+    max_stack_size: usize
 }
 
 #[derive(Debug, PartialEq)]
 enum AccessError {
     DoubleMalloc {addr: usize, len: usize},
-    InvalidReadWrite {addr: usize, len: usize},
+    InvalidRead {addr: usize, len: usize},
+    InvalidWrite {addr: usize, len: usize},
     DoubleFree {addr: usize, len: usize},
     OutOfBounds {addr: usize, len: usize},
 }
@@ -22,20 +21,21 @@ enum MemState {
 }
 
 impl Valgrind {
-    fn new(mem_size: usize) -> Valgrind {
+    fn new(mem_size: usize, max_stack_size: usize) -> Valgrind {
         let metadata = vec![MemState::Unallocated; mem_size];
-        Valgrind { metadata }
+        //stack_pointer indicated highest byte of stack (inclusive), so stack is always from 0..stack_pointer
+        let stack_pointer = max_stack_size;
+        Valgrind { metadata, stack_pointer, max_stack_size }
     }
     fn malloc(&mut self, addr: usize, len: usize) -> Result<(), AccessError> {
         if !self.is_in_bounds(addr, len) {
             return Err(AccessError::OutOfBounds {addr: addr, len: len});
         }
         for i in addr..addr+len {
-            // feels a bit redundant, would love to change logic to if !Unallocated then 
-            // error but couldn't figure out how using 'if let' statements 
             if let MemState::ValidToWrite = self.metadata[i] {
                 return Err(AccessError::DoubleMalloc {addr: addr, len: len});
-            } if let MemState::ValidToReadWrite = self.metadata[i] {
+            }
+            if let MemState::ValidToReadWrite = self.metadata[i] {
                 return Err(AccessError::DoubleMalloc {addr: addr, len: len});
             }
             self.metadata[i] = MemState::ValidToWrite;
@@ -48,9 +48,10 @@ impl Valgrind {
         }
         for i in addr..addr+len {
             if let MemState::Unallocated = self.metadata[i] {
-                return Err(AccessError::InvalidReadWrite {addr: addr, len: len});
-            } if let MemState::ValidToWrite = self.metadata[i] {
-                return Err(AccessError::InvalidReadWrite {addr: addr, len: len});
+                return Err(AccessError::InvalidRead {addr: addr, len: len});
+            }
+            if let MemState::ValidToWrite = self.metadata[i] {
+                return Err(AccessError::InvalidRead {addr: addr, len: len});
             }
         }
         Ok(())
@@ -61,7 +62,7 @@ impl Valgrind {
         }
         for i in addr..addr+len {
             if let MemState::Unallocated = self.metadata[i] {
-                return Err(AccessError::InvalidReadWrite {addr: addr, len: len});
+                return Err(AccessError::InvalidWrite {addr: addr, len: len});
             }
             self.metadata[i] = MemState::ValidToReadWrite
         }
@@ -80,13 +81,25 @@ impl Valgrind {
         Ok(())
     }
     fn is_in_bounds(&self, addr: usize, len: usize) -> bool {
-        addr + len <= self.metadata.len()
+        addr + len <= self.metadata.len() && self.max_stack_size < addr
+    }
+    fn shrink_stack(&mut self, num_bytes: usize) {
+        for i in self.stack_pointer..self.stack_pointer + num_bytes {
+            self.metadata[i] = MemState::Unallocated;
+        }
+        self.stack_pointer = std::cmp::min(self.max_stack_size, self.stack_pointer + num_bytes);
+    }
+    fn grow_stack(&mut self, num_bytes: usize) {
+        for i in self.stack_pointer - num_bytes..self.stack_pointer {
+            self.metadata[i] = MemState::ValidToReadWrite;
+        }
+        self.stack_pointer = std::cmp::max(0, self.stack_pointer - num_bytes);
     }
 }
 
 #[test]
 fn basic_valgrind() {
-    let mut valgrind_state = Valgrind::new(640 * 1024);
+    let mut valgrind_state = Valgrind::new(640 * 1024, 0);
 
     assert!(valgrind_state.malloc(0x1000, 32).is_ok());
     assert!(valgrind_state.write(0x1000, 4).is_ok());
@@ -96,29 +109,29 @@ fn basic_valgrind() {
 
 #[test]
 fn read_before_initializing() {
-    let mut valgrind_state = Valgrind::new(640 * 1024);
+    let mut valgrind_state = Valgrind::new(640 * 1024, 0);
 
     assert!(valgrind_state.malloc(0x1000, 32).is_ok());
-    assert_eq!(valgrind_state.read(0x1000, 4), Err(AccessError::InvalidReadWrite {addr: 0x1000, len: 4}));
+    assert_eq!(valgrind_state.read(0x1000, 4), Err(AccessError::InvalidRead {addr: 0x1000, len: 4}));
     assert!(valgrind_state.write(0x1000, 4).is_ok());
     assert!(valgrind_state.free(0x1000, 32).is_ok());
 }
 
 #[test]
 fn use_after_free() {
-    let mut valgrind_state = Valgrind::new(640 * 1024);
+    let mut valgrind_state = Valgrind::new(640 * 1024, 0);
 
     assert!(valgrind_state.malloc(0x1000, 32).is_ok());
     assert!(valgrind_state.write(0x1000, 4).is_ok());
     assert!(valgrind_state.write(0x1000, 4).is_ok());
     assert!(valgrind_state.free(0x1000, 32).is_ok());
-    assert_eq!(valgrind_state.write(0x1000, 4), Err(AccessError::InvalidReadWrite {addr: 0x1000, len: 4}));
+    assert_eq!(valgrind_state.write(0x1000, 4), Err(AccessError::InvalidWrite {addr: 0x1000, len: 4}));
 }
 
 
 #[test]
 fn double_free() {
-    let mut valgrind_state = Valgrind::new(640 * 1024);
+    let mut valgrind_state = Valgrind::new(640 * 1024, 0);
 
     assert!(valgrind_state.malloc(0x1000, 32).is_ok());
     assert!(valgrind_state.write(0x1000, 4).is_ok());
@@ -128,7 +141,7 @@ fn double_free() {
 
 #[test]
 fn out_of_bounds_malloc() {
-    let mut valgrind_state = Valgrind::new(640 * 1024);
+    let mut valgrind_state = Valgrind::new(640 * 1024, 0);
 
     assert_eq!(valgrind_state.malloc(640 * 1024, 1), Err(AccessError::OutOfBounds {addr: 640 * 1024, len: 1}));
     assert_eq!(valgrind_state.malloc(640 * 1024 - 10, 15), Err(AccessError::OutOfBounds {addr: 640 * 1024 - 10, len: 15}));
@@ -136,7 +149,7 @@ fn out_of_bounds_malloc() {
 
 #[test]
 fn out_of_bounds_read() {
-    let mut valgrind_state = Valgrind::new(640 * 1024);
+    let mut valgrind_state = Valgrind::new(640 * 1024, 0);
 
     assert!(valgrind_state.malloc(640 * 1024 - 24, 24).is_ok());
     assert_eq!(valgrind_state.read(640 * 1024 - 24, 25), Err(AccessError::OutOfBounds {addr: 640 * 1024 - 24, len: 25}));
@@ -144,7 +157,7 @@ fn out_of_bounds_read() {
 
 #[test]
 fn double_malloc() {
-    let mut valgrind_state = Valgrind::new(640 * 1024);
+    let mut valgrind_state = Valgrind::new(640 * 1024, 0);
 
     assert!(valgrind_state.malloc(0x1000, 32).is_ok());
     assert_eq!(valgrind_state.malloc(0x1000, 32), Err(AccessError::DoubleMalloc {addr: 0x1000, len: 32}));
@@ -153,9 +166,40 @@ fn double_malloc() {
 
 #[test]
 fn error_type() {
-    let mut valgrind_state = Valgrind::new(640 * 1024);
+    let mut valgrind_state = Valgrind::new(640 * 1024, 0);
 
     assert!(valgrind_state.malloc(0x1000, 32).is_ok());
     assert_eq!(valgrind_state.malloc(0x1000, 32), Err(AccessError::DoubleMalloc {addr: 0x1000, len: 32}));
     assert_eq!(valgrind_state.malloc(640 * 1024, 32), Err(AccessError::OutOfBounds {addr: 640 * 1024, len: 32}));
+}
+
+#[test]
+fn stack_grow_no_error() {
+    let mut valgrind_state = Valgrind::new(640 * 1024, 1024);
+
+    assert_eq!(valgrind_state.max_stack_size, 1024);
+    valgrind_state.grow_stack(256);
+    assert_eq!(valgrind_state.stack_pointer, 768);
+    assert!(valgrind_state.malloc(1024 * 2, 32).is_ok());
+    assert!(valgrind_state.free(1024 * 2, 32).is_ok());
+}
+
+#[test]
+fn bad_stack_malloc() {
+    let mut valgrind_state = Valgrind::new(640 * 1024, 1024);
+
+    valgrind_state.grow_stack(1024);
+    assert_eq!(valgrind_state.stack_pointer, 0);
+    assert_eq!(valgrind_state.malloc(512, 32), Err(AccessError::OutOfBounds {addr: 512, len: 32}));
+    assert_eq!(valgrind_state.malloc(1022, 32), Err(AccessError::OutOfBounds {addr: 1022, len: 32}));
+}
+
+#[test]
+fn bad_stack_access() {
+    let mut valgrind_state = Valgrind::new(640 * 1024, 1024);
+
+    valgrind_state.grow_stack(512);
+    assert_eq!(valgrind_state.stack_pointer, 512);
+    assert_eq!(valgrind_state.read(256, 16), Err(AccessError::OutOfBounds {addr: 256, len: 16}));
+    assert_eq!(valgrind_state.write(500, 32), Err(AccessError::OutOfBounds {addr: 500, len: 32}));
 }


### PR DESCRIPTION
- added argument for maximum stack size when initializing valgrind instance (not sure if this should be set to a 1MiB constant instead?)
- grow/shrink stack functions
- valgrind struct changes:
      + stack_pointer: top of stack
      + max_stack_size: bottom of stack (assuming stack is 0..max_stack_size)